### PR TITLE
changes list group active color

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -730,7 +730,7 @@ $list-group-item-padding-x:         $input-padding-x;
 
 $list-group-hover-bg:               theme-color-hover('primary');
 //$list-group-active-color:           $component-active-color !default;
-$list-group-active-bg:              theme-color-hover('primary');
+$list-group-active-bg:              $blue;
 //$list-group-active-border-color:    $list-group-active-bg !default;
 
 $list-group-disabled-color:         $light-gray;


### PR DESCRIPTION
The list group had incorrect color when it was on active state. It now looks like this:

![list_group](https://user-images.githubusercontent.com/17051250/52272574-e86b1d80-294f-11e9-9d33-59a32cc9d784.png)

@TristanLDD maybe there are more incorrect colors ? :thinking: 