### PR TITLE
Add help-box and improve popover component

### DIFF
--- a/index.html
+++ b/index.html
@@ -2660,6 +2660,10 @@
             <button type="button" class="btn btn-outline-primary" data-container="body" data-toggle="popover" data-placement="right" title="Dismissible popover" data-content="Vivamus sagittis lacus vel augue laoreet rutrum faucibus.">
                 Popover on right  (with title)
             </button>
+
+            <span class="help-box" data-container="body" data-toggle="popover" data-placement="right" title="Dismissible popover" data-content="Vivamus sagittis lacus vel augue laoreet rutrum faucibus.">
+                <i class="material-icons">info</i>
+            </span>
         </article>
 
         <article id="progress">

--- a/scss/_help-box.scss
+++ b/scss/_help-box.scss
@@ -1,0 +1,11 @@
+$component-name: help-box;
+
+.#{$component-name} {
+    margin: 0 10px;
+    cursor: pointer;
+
+    i {
+        font-size: 14px;
+        color: $primary;
+    }
+}

--- a/scss/_popover.scss
+++ b/scss/_popover.scss
@@ -1,0 +1,43 @@
+$component-name: popover;
+
+.#{$component-name} {
+    padding: 5px;
+    background: $gray-700;
+    border: none;
+
+    & &-header,
+    & &-body {
+        color: #ffffff;
+        background: none;
+        border: none;
+        padding: 0;
+    }
+
+    &.bs-popover-right .arrow {
+        &::before,
+        &::after {
+            border-right-color: $gray-700;
+        }
+    }
+
+    &.bs-popover-left .arrow {
+        &::before,
+        &::after {
+            border-left-color: $gray-700;
+        }
+    }
+
+    &.bs-popover-bottom .arrow {
+        &::before,
+        &::after {
+            border-bottom-color: $gray-700;
+        }
+    }
+
+    &.bs-popover-top .arrow {
+        &::before,
+        &::after {
+            border-top-color: $gray-700;
+        }
+    }
+}

--- a/scss/_popover.scss
+++ b/scss/_popover.scss
@@ -14,6 +14,8 @@ $component-name: popover;
     }
 
     &.bs-popover-right .arrow {
+        left: calc((0.5rem) * -1);
+
         &::before,
         &::after {
             border-right-color: $gray-700;
@@ -21,6 +23,8 @@ $component-name: popover;
     }
 
     &.bs-popover-left .arrow {
+        right: calc((0.5rem) * -1);
+
         &::before,
         &::after {
             border-left-color: $gray-700;
@@ -28,6 +32,8 @@ $component-name: popover;
     }
 
     &.bs-popover-bottom .arrow {
+        top: calc((0.5rem) * -1);
+
         &::before,
         &::after {
             border-bottom-color: $gray-700;
@@ -35,6 +41,8 @@ $component-name: popover;
     }
 
     &.bs-popover-top .arrow {
+        bottom: calc((0.5rem) * -1);
+
         &::before,
         &::after {
             border-top-color: $gray-700;

--- a/scss/application.scss
+++ b/scss/application.scss
@@ -21,6 +21,8 @@
 // Components
 @import "type";
 @import "alerts";
+@import "help-box";
+@import "popover";
 @import "badges";
 @import "buttons";
 @import "button-group";


### PR DESCRIPTION
Related to https://github.com/PrestaShop/PrestaShop/issues/16603

How to test : Build assets (npm run build or npm run watch) and then compare with issue's specs on the index.html of the UI Kit, if there are var missing, it's because past PR's needs to be merged before..

Help box is at bottom at the page 