### PR TITLE
Update bootstrap version from 4.0 to 4.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1485,9 +1485,9 @@
       "dev": true
     },
     "bootstrap": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.0.0.tgz",
-      "integrity": "sha512-gulJE5dGFo6Q61V/whS6VM4WIyrlydXfCgkE+Gxe5hjrJ8rXLLZlALq7zq2RPhOc45PSwQpJkrTnc2KgD6cvmA==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.4.1.tgz",
+      "integrity": "sha512-tbx5cHubwE6e2ZG7nqM3g/FZ5PQEDMWmMGNrCUBVRPHXTJaH7CBDdsLeu3eCh3B1tzAxTnAbtmrzvWEvT2NNEA==",
       "dev": true
     },
     "brace-expansion": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "babel-plugin-transform-es2015-modules-strip": "^0.1.1",
     "babel-preset-env": "^1.6.1",
     "babel-preset-es2015": "^6.24.1",
-    "bootstrap": "^4.0.0",
+    "bootstrap": "^4.4.1",
     "css-loader": "^0.28.11",
     "expose-loader": "^0.7.5",
     "extract-text-webpack-plugin": "^3.0.2",
@@ -44,8 +44,8 @@
     "select2-bootstrap-theme": "0.1.0-beta.10",
     "style-loader": "^0.18.2",
     "stylelint": "^12.0.0",
+    "stylelint-config-prestashop": "^1.0.2",
     "tether": "^1.4.3",
-    "webpack": "^3.11.0",
-    "stylelint-config-prestashop": "^1.0.2"
+    "webpack": "^3.11.0"
   }
 }


### PR DESCRIPTION
The goal is to update boostrap to the most recent version to help everyone using the uikit

QA : You need to build the assets and check if index.html is the same as before on develop

Also you can change the dependency on prestashop of new-theme and default to the relative path of the uikit, build assets and check if nothing break on prestashop !

Don't hesitate to contact me if you need help with testing