### PR TITLE
Make SCSS importable from Prestakit as a npm dependency and add webpack babel presets

### DIFF
--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -4,7 +4,7 @@
   border-width: $border-width;
   @include border-radius($btn-border-radius);
 
-  @include hover-focus () {
+  @include hover-focus() {
     cursor: pointer;
   }
 
@@ -18,15 +18,10 @@
   > .material-icons {
     font-size: 1.45em;
     margin-top: -0.083em;
-    margin-right: .4em;
   }
 
   &-default {
-    @include ps-button-outline-variant(
-      $gray-700,
-      $primary,
-      'default'
-    );
+    @include ps-button-outline-variant($gray-700, $primary, "default");
 
     border-color: $gray-300;
 
@@ -62,4 +57,3 @@
     @include ps-button-outline-variant($value, #fff, $color);
   }
 }
-

--- a/scss/_ps-number.scss
+++ b/scss/_ps-number.scss
@@ -1,31 +1,20 @@
 $component-name: ps-number;
 
 .#{$component-name} {
-    position: relative;
+  position: relative;
 
-    & &-inputs {
-        display: flex;
-        align-items: center;
+  & &-inputs {
+    display: flex;
+    align-items: center;
+  }
+
+  & &-controls {
+    margin-left: 5px;
+  }
+
+  .invalid-feedback {
+    &.show {
+      display: block;
     }
-
-    & &-controls {
-        margin-left: 5px;
-    }
-
-    .invalid-feedback {
-        &.show {
-            display: block;
-        }
-
-        &::after {
-            @include material-icon("\E000");
-            position: absolute;
-            right: 6.8rem;
-            bottom: 1.813rem;
-            font-size: 1.438rem;
-            font-weight: $font-weight-normal;
-            vertical-align: middle;
-            color: theme-color("danger");
-        }
-    }
+  }
 }

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -49,6 +49,8 @@ $primary-active: #21a6c1;
 $primary-disabled: #d3f1f7;
 $secondary-hover: #b7ced3;
 $secondary-active: #889da2;
+$danger-hover: #fde1e1;
+$notice: #dff5f9;
 
 $primary: $blue !default;
 $secondary: $medium-gray;
@@ -219,7 +221,7 @@ $grid-gutter-width: 1.875rem !default;
 //$border-width:                1px !default;
 //$border-color:                $gray-300 !default;
 
-//$border-radius:               .25rem !default;
+$border-radius: 4px !default;
 //$border-radius-lg:            .3rem !default;
 //$border-radius-sm:            .2rem !default;
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -23,6 +23,10 @@ $light-gray: $gray-300;
 $medium-gray: $gray-500;
 $dark-gray: $gray-700;
 $extra-dark-gray: $gray-900;
+$gray-light: $light-gray;
+$gray-medium: $medium-gray;
+$gray-dark: $dark-gray;
+$gray-soft: $gray-200;
 $background-color: #eff1f2;
 $primary-lighten: #f4fcfd;
 
@@ -54,6 +58,20 @@ $warning: $yellow !default;
 $danger: $red !default;
 $light: $gray-100 !default;
 $dark: $gray-800 !default;
+
+$brand-primary: $primary !default;
+$brand-secondary: $secondary !default;
+$brand-info: #5bc0de !default;
+$brand-warning: #f0ad4e !default;
+$brand-success: $success !default;
+$brand-danger: $danger !default;
+
+$btn-primary-bg: $primary-hover;
+$btn-secondary-border: #000;
+$btn-info-bg: $brand-info !default;
+$btn-success-bg: $brand-success !default;
+$btn-warning-bg: $brand-warning !default;
+$btn-danger-bg: $brand-danger !default;
 
 $theme-colors: (
   "primary": $primary,
@@ -192,7 +210,7 @@ $container-max-widths: (
 
 // Grid columns
 //$grid-columns:                12 !default;
-//$grid-gutter-width:           30px !default;
+$grid-gutter-width: 1.875rem !default;
 
 // Components
 //$line-height-lg:              1.5 !default;
@@ -609,10 +627,14 @@ $jumbotron-padding: 2rem !default;
 $jumbotron-bg: $extra-light-gray;
 
 // Cards
-//$card-spacer-y:                     .75rem !default;
-//$card-spacer-x:                     1.25rem !default;
-$card-border-width: 0 !default;
+$card-spacer-x: 0.625rem !default;
+$card-spacer-y: 0.625rem !default;
+$card-border-width: 1px !default;
 $card-border-radius: 5px !default;
+$card-border-radius-inner: $card-border-radius !default;
+$card-cap-bg: $gray-200 !default;
+$card-bg: #fff !default;
+$card-link-hover-color: #fff !default;
 $card-border-color: $light-gray;
 //$card-inner-border-radius:          calc(#{$card-border-radius} - #{$card-border-width}) !default;
 //$card-cap-bg:                       rgba($black, .03) !default;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -635,7 +635,7 @@ $card-border-radius-inner: $card-border-radius !default;
 $card-cap-bg: $gray-200 !default;
 $card-bg: #fff !default;
 $card-link-hover-color: #fff !default;
-$card-border-color: $light-gray;
+$card-border-color: #dbe6e9 !default;
 //$card-inner-border-radius:          calc(#{$card-border-radius} - #{$card-border-width}) !default;
 //$card-cap-bg:                       rgba($black, .03) !default;
 //$card-bg:                           $white !default;

--- a/scss/application.scss
+++ b/scss/application.scss
@@ -16,7 +16,7 @@
 
 // Addons
 @import "~select2/src/scss/core.scss";
-@import "~jquery.growl/stylesheets/jquery.growl.css";
+@import "~jquery.growl/stylesheets/jquery.growl.sass";
 
 // Utils
 @import "utils/animations";

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,7 +18,10 @@ let config = {
     rules: [
       {
         test: /\.js/,
-        loader: 'babel-loader'
+        loader: 'babel-loader',
+        options: {
+          presets: [['env', {useBuiltIns: 'usage', modules: false}]]
+        }
       },
       {
         test: require.resolve('jquery'),


### PR DESCRIPTION
This is required from the core to make able to use variables from the UIKit and also strongly required to use this module externally from PS, for example to develop a module properly

How to test : verify that you can `npm install && npm run build` then check on the index page is everything is fine (didn't change that much, that should be fine)