### PR TITLE
Moove dev dependencies into prod to make source importable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "prestakit",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10850,7 +10850,7 @@
       "dev": true
     },
     "pstagger": {
-      "version": "git+https://github.com/PrestaShop/pstagger.git#fdf43c6986f2e66ae2eba1f403ef0e569519b64c",
+      "version": "git+https://github.com/PrestaShop/pstagger.git",
       "from": "git+https://github.com/PrestaShop/pstagger.git",
       "dev": true
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -7432,8 +7432,7 @@
     "open-sans-fonts": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/open-sans-fonts/-/open-sans-fonts-1.6.2.tgz",
-      "integrity": "sha512-vsJ6/Mm0TdUKQJqxfkXJy+0K2X0QeRuTmxQq9YE1ycziw6CbDPolDsHhQ6+ImoV/7OTh8K8ZTGklY1Z5nUAwug==",
-      "dev": true
+      "integrity": "sha512-vsJ6/Mm0TdUKQJqxfkXJy+0K2X0QeRuTmxQq9YE1ycziw6CbDPolDsHhQ6+ImoV/7OTh8K8ZTGklY1Z5nUAwug=="
     },
     "os-browserify": {
       "version": "0.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -659,8 +659,7 @@
     "almond": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/almond/-/almond-0.3.3.tgz",
-      "integrity": "sha1-oOfJWsdiTWQXtElLHmi/9pMWiiA=",
-      "dev": true
+      "integrity": "sha1-oOfJWsdiTWQXtElLHmi/9pMWiiA="
     },
     "alphanum-sort": {
       "version": "1.0.2",
@@ -6362,14 +6361,12 @@
     "jquery-mousewheel": {
       "version": "3.1.13",
       "resolved": "https://registry.npmjs.org/jquery-mousewheel/-/jquery-mousewheel-3.1.13.tgz",
-      "integrity": "sha1-BvAzXxbjU6aV5yBr9QUDy1I6buU=",
-      "dev": true
+      "integrity": "sha1-BvAzXxbjU6aV5yBr9QUDy1I6buU="
     },
     "jquery.growl": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/jquery.growl/-/jquery.growl-1.3.5.tgz",
-      "integrity": "sha1-+hxNdY4NdoZVHhWJaxqqwrsa9/E=",
-      "dev": true
+      "integrity": "sha1-+hxNdY4NdoZVHhWJaxqqwrsa9/E="
     },
     "js-base64": {
       "version": "2.3.2",
@@ -11578,7 +11575,6 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/select2/-/select2-4.0.5.tgz",
       "integrity": "sha1-eqxQaSVhmFs007guxV4ib4lg1Ao=",
-      "dev": true,
       "requires": {
         "almond": "~0.3.1",
         "jquery-mousewheel": "~3.1.13"
@@ -11587,8 +11583,7 @@
     "select2-bootstrap-theme": {
       "version": "0.1.0-beta.10",
       "resolved": "https://registry.npmjs.org/select2-bootstrap-theme/-/select2-bootstrap-theme-0.1.0-beta.10.tgz",
-      "integrity": "sha1-uUJuz8A79KI152oTI3dXQxBGmsA=",
-      "dev": true
+      "integrity": "sha1-uUJuz8A79KI152oTI3dXQxBGmsA="
     },
     "semver": {
       "version": "5.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1764,8 +1764,7 @@
     "bootstrap": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.4.1.tgz",
-      "integrity": "sha512-tbx5cHubwE6e2ZG7nqM3g/FZ5PQEDMWmMGNrCUBVRPHXTJaH7CBDdsLeu3eCh3B1tzAxTnAbtmrzvWEvT2NNEA==",
-      "dev": true
+      "integrity": "sha512-tbx5cHubwE6e2ZG7nqM3g/FZ5PQEDMWmMGNrCUBVRPHXTJaH7CBDdsLeu3eCh3B1tzAxTnAbtmrzvWEvT2NNEA=="
     },
     "brace-expansion": {
       "version": "1.1.8",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "jquery.growl": "^1.3.5",
+    "bootstrap": "^4.4.1",
     "select2": "^4.0.5",
     "select2-bootstrap-theme": "0.1.0-beta.10"
   },
@@ -33,7 +34,6 @@
     "babel-plugin-transform-es2015-modules-strip": "^0.1.1",
     "babel-preset-env": "^1.6.1",
     "babel-preset-es2015": "^6.24.1",
-    "bootstrap": "^4.4.1",
     "css-loader": "^0.28.11",
     "expose-loader": "^0.7.5",
     "file-loader": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,10 @@
   "bugs": {
     "url": "https://github.com/PrestaShop/prestashop-ui-kit/issues"
   },
+  "dependencies": {
+    "select2": "^4.0.5",
+    "select2-bootstrap-theme": "0.1.0-beta.10"
+  },
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
@@ -44,8 +48,6 @@
     "postcss-preset-env": "^6.7.0",
     "pstagger": "git+https://github.com/PrestaShop/pstagger.git",
     "sass-loader": "^6.0.7",
-    "select2": "^4.0.5",
-    "select2-bootstrap-theme": "0.1.0-beta.10",
     "style-loader": "^0.18.2",
     "stylelint": "^12.0.0",
     "stylelint-config-prestashop": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "url": "https://github.com/PrestaShop/prestashop-ui-kit/issues"
   },
   "dependencies": {
+    "jquery.growl": "^1.3.5",
     "select2": "^4.0.5",
     "select2-bootstrap-theme": "0.1.0-beta.10"
   },
@@ -37,7 +38,6 @@
     "expose-loader": "^0.7.5",
     "file-loader": "^6.0.0",
     "jquery": "^3.5.0",
-    "jquery.growl": "^1.3.5",
     "material-design-icons-iconfont": "^5.0.1",
     "mini-css-extract-plugin": "^0.9.0",
     "node-sass": "^4.13.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "jquery.growl": "^1.3.5",
     "bootstrap": "^4.4.1",
     "select2": "^4.0.5",
-    "select2-bootstrap-theme": "0.1.0-beta.10"
+    "select2-bootstrap-theme": "0.1.0-beta.10",
+    "open-sans-fonts": "^1.6.2"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
@@ -41,7 +42,6 @@
     "material-design-icons-iconfont": "^5.0.1",
     "mini-css-extract-plugin": "^0.9.0",
     "node-sass": "^4.13.0",
-    "open-sans-fonts": "^1.6.2",
     "popper.js": "^1.14.1",
     "postcss-cssnext": "^2.11.0",
     "postcss-loader": "^2.1.3",

--- a/scss/_imports.scss
+++ b/scss/_imports.scss
@@ -1,7 +1,7 @@
 // Open Sans
 /* stylelint-disable */
 
-$FontPathOpenSans: "~prestakit/node_modules/open-sans-fonts/open-sans";
+$FontPathOpenSans: "~open-sans-fonts/open-sans";
 
 @mixin setFont() {
   @if $local-font {
@@ -10,160 +10,188 @@ $FontPathOpenSans: "~prestakit/node_modules/open-sans-fonts/open-sans";
       font-style: normal;
       font-weight: 400;
       src: url("~material-design-icons-iconfont/dist/fonts/MaterialIcons-Regular.eot"); /* For IE6-8 */
-      src:
-        local("Material Icons"), local("MaterialIcons-Regular"), url("~material-design-icons-iconfont/dist/fonts/MaterialIcons-Regular.woff2")
-        format("woff2"), url("~material-design-icons-iconfont/dist/fonts/MaterialIcons-Regular.woff")
-        format("woff"), url("~material-design-icons-iconfont/dist/fonts/MaterialIcons-Regular.ttf")
-        format("truetype");
+      src: local("Material Icons"), local("MaterialIcons-Regular"),
+        url("~material-design-icons-iconfont/dist/fonts/MaterialIcons-Regular.woff2")
+          format("woff2"),
+        url("~material-design-icons-iconfont/dist/fonts/MaterialIcons-Regular.woff")
+          format("woff"),
+        url("~material-design-icons-iconfont/dist/fonts/MaterialIcons-Regular.ttf")
+          format("truetype");
     }
 
     @font-face {
       font-family: "Open Sans";
       font-style: normal;
       font-weight: 300;
-      src:
-        url("#{$FontPathOpenSans}/Light/OpenSans-Light.woff2")
-        format("woff2"), url("#{$FontPathOpenSans}/Light/OpenSans-Light.woff") format("woff"), url("#{$FontPathOpenSans}/Light/OpenSans-Light.ttf") format("truetype"), url("#{$FontPathOpenSans}/Light/OpenSans-Light.svg#OpenSansLight")
-        format("svg");
+      src: url("#{$FontPathOpenSans}/Light/OpenSans-Light.woff2")
+          format("woff2"),
+        url("#{$FontPathOpenSans}/Light/OpenSans-Light.woff") format("woff"),
+        url("#{$FontPathOpenSans}/Light/OpenSans-Light.ttf") format("truetype"),
+        url("#{$FontPathOpenSans}/Light/OpenSans-Light.svg#OpenSansLight")
+          format("svg");
     }
 
     @font-face {
       font-family: "Open Sans";
       font-style: italic;
       font-weight: 300;
-      src:
-        url("#{$FontPathOpenSans}/LightItalic/OpenSans-LightItalic.woff2")
-        format("woff2"), url("#{$FontPathOpenSans}/LightItalic/OpenSans-LightItalic.woff")
-        format("woff"), url("#{$FontPathOpenSans}/LightItalic/OpenSans-LightItalic.ttf")
-        format("truetype"), url("#{$FontPathOpenSans}/LightItalic/OpenSans-LightItalic.svg#OpenSansLightItalic")
-        format("svg");
+      src: url("#{$FontPathOpenSans}/LightItalic/OpenSans-LightItalic.woff2")
+          format("woff2"),
+        url("#{$FontPathOpenSans}/LightItalic/OpenSans-LightItalic.woff")
+          format("woff"),
+        url("#{$FontPathOpenSans}/LightItalic/OpenSans-LightItalic.ttf")
+          format("truetype"),
+        url("#{$FontPathOpenSans}/LightItalic/OpenSans-LightItalic.svg#OpenSansLightItalic")
+          format("svg");
     }
 
     @font-face {
       font-family: "Open Sans";
       font-style: normal;
       font-weight: normal;
-      src:
-        url("#{$FontPathOpenSans}/Regular/OpenSans-Regular.woff2")
-        format("woff2"), url("#{$FontPathOpenSans}/Regular/OpenSans-Regular.woff") format("woff"), url("#{$FontPathOpenSans}/Regular/OpenSans-Regular.ttf")
-        format("truetype"), url("#{$FontPathOpenSans}/Regular/OpenSans-Regular.svg#OpenSansRegular")
-        format("svg");
+      src: url("#{$FontPathOpenSans}/Regular/OpenSans-Regular.woff2")
+          format("woff2"),
+        url("#{$FontPathOpenSans}/Regular/OpenSans-Regular.woff") format("woff"),
+        url("#{$FontPathOpenSans}/Regular/OpenSans-Regular.ttf")
+          format("truetype"),
+        url("#{$FontPathOpenSans}/Regular/OpenSans-Regular.svg#OpenSansRegular")
+          format("svg");
     }
 
     @font-face {
       font-family: "Open Sans";
       font-style: italic;
       font-weight: normal;
-      src:
-        url("#{$FontPathOpenSans}/Italic/OpenSans-Italic.woff2")
-        format("woff2"), url("#{$FontPathOpenSans}/Italic/OpenSans-Italic.woff") format("woff"), url("#{$FontPathOpenSans}/Italic/OpenSans-Italic.ttf")
-        format("truetype"), url("#{$FontPathOpenSans}/Italic/OpenSans-Italic.svg#OpenSansItalic")
-        format("svg");
+      src: url("#{$FontPathOpenSans}/Italic/OpenSans-Italic.woff2")
+          format("woff2"),
+        url("#{$FontPathOpenSans}/Italic/OpenSans-Italic.woff") format("woff"),
+        url("#{$FontPathOpenSans}/Italic/OpenSans-Italic.ttf")
+          format("truetype"),
+        url("#{$FontPathOpenSans}/Italic/OpenSans-Italic.svg#OpenSansItalic")
+          format("svg");
     }
 
     @font-face {
       font-family: "Open Sans";
       font-style: normal;
       font-weight: 600;
-      src:
-        url("#{$FontPathOpenSans}/Semibold/OpenSans-Semibold.woff2")
-        format("woff2"), url("#{$FontPathOpenSans}/Semibold/OpenSans-Semibold.woff")
-        format("woff"), url("#{$FontPathOpenSans}/Semibold/OpenSans-Semibold.ttf")
-        format("truetype"), url("#{$FontPathOpenSans}/Semibold/OpenSans-Semibold.svg#OpenSansSemibold")
-        format("svg");
+      src: url("#{$FontPathOpenSans}/Semibold/OpenSans-Semibold.woff2")
+          format("woff2"),
+        url("#{$FontPathOpenSans}/Semibold/OpenSans-Semibold.woff")
+          format("woff"),
+        url("#{$FontPathOpenSans}/Semibold/OpenSans-Semibold.ttf")
+          format("truetype"),
+        url("#{$FontPathOpenSans}/Semibold/OpenSans-Semibold.svg#OpenSansSemibold")
+          format("svg");
     }
 
     @font-face {
       font-family: "Open Sans";
       font-style: italic;
       font-weight: 600;
-      src:
-        url("#{$FontPathOpenSans}/SemiboldItalic/OpenSans-SemiboldItalic.woff2")
-        format("woff2"), url("#{$FontPathOpenSans}/SemiboldItalic/OpenSans-SemiboldItalic.woff")
-        format("woff"), url("#{$FontPathOpenSans}/SemiboldItalic/OpenSans-SemiboldItalic.ttf")
-        format("truetype"), url("#{$FontPathOpenSans}/SemiboldItalic/OpenSans-SemiboldItalic.svg#OpenSansSemiboldItalic")
-        format("svg");
+      src: url("#{$FontPathOpenSans}/SemiboldItalic/OpenSans-SemiboldItalic.woff2")
+          format("woff2"),
+        url("#{$FontPathOpenSans}/SemiboldItalic/OpenSans-SemiboldItalic.woff")
+          format("woff"),
+        url("#{$FontPathOpenSans}/SemiboldItalic/OpenSans-SemiboldItalic.ttf")
+          format("truetype"),
+        url("#{$FontPathOpenSans}/SemiboldItalic/OpenSans-SemiboldItalic.svg#OpenSansSemiboldItalic")
+          format("svg");
     }
 
     @font-face {
       font-family: "Open Sans";
       font-style: normal;
       font-weight: bold;
-      src:
-        url("#{$FontPathOpenSans}/Bold/OpenSans-Bold.woff2") format("woff2"), url("#{$FontPathOpenSans}/Bold/OpenSans-Bold.woff") format("woff"), url("#{$FontPathOpenSans}/Bold/OpenSans-Bold.ttf") format("truetype"), url("#{$FontPathOpenSans}/Bold/OpenSans-Bold.svg#OpenSansBold")
-        format("svg");
+      src: url("#{$FontPathOpenSans}/Bold/OpenSans-Bold.woff2") format("woff2"),
+        url("#{$FontPathOpenSans}/Bold/OpenSans-Bold.woff") format("woff"),
+        url("#{$FontPathOpenSans}/Bold/OpenSans-Bold.ttf") format("truetype"),
+        url("#{$FontPathOpenSans}/Bold/OpenSans-Bold.svg#OpenSansBold")
+          format("svg");
     }
 
     @font-face {
       font-family: "Open Sans";
       font-style: italic;
       font-weight: bold;
-      src:
-        url("#{$FontPathOpenSans}/BoldItalic/OpenSans-BoldItalic.woff2")
-        format("woff2"), url("#{$FontPathOpenSans}/BoldItalic/OpenSans-BoldItalic.woff")
-        format("woff"), url("#{$FontPathOpenSans}/BoldItalic/OpenSans-BoldItalic.ttf")
-        format("truetype"), url("#{$FontPathOpenSans}/BoldItalic/OpenSans-BoldItalic.svg#OpenSansBoldItalic")
-        format("svg");
+      src: url("#{$FontPathOpenSans}/BoldItalic/OpenSans-BoldItalic.woff2")
+          format("woff2"),
+        url("#{$FontPathOpenSans}/BoldItalic/OpenSans-BoldItalic.woff")
+          format("woff"),
+        url("#{$FontPathOpenSans}/BoldItalic/OpenSans-BoldItalic.ttf")
+          format("truetype"),
+        url("#{$FontPathOpenSans}/BoldItalic/OpenSans-BoldItalic.svg#OpenSansBoldItalic")
+          format("svg");
     }
 
     @font-face {
       font-family: "Open Sans";
       font-style: normal;
       font-weight: 800;
-      src:
-        url("#{$FontPathOpenSans}/ExtraBold/OpenSans-ExtraBold.woff2")
-        format("woff2"), url("#{$FontPathOpenSans}/ExtraBold/OpenSans-ExtraBold.woff")
-        format("woff"), url("#{$FontPathOpenSans}/ExtraBold/OpenSans-ExtraBold.ttf")
-        format("truetype"), url("#{$FontPathOpenSans}/ExtraBold/OpenSans-ExtraBold.svg#OpenSansExtrabold")
-        format("svg");
+      src: url("#{$FontPathOpenSans}/ExtraBold/OpenSans-ExtraBold.woff2")
+          format("woff2"),
+        url("#{$FontPathOpenSans}/ExtraBold/OpenSans-ExtraBold.woff")
+          format("woff"),
+        url("#{$FontPathOpenSans}/ExtraBold/OpenSans-ExtraBold.ttf")
+          format("truetype"),
+        url("#{$FontPathOpenSans}/ExtraBold/OpenSans-ExtraBold.svg#OpenSansExtrabold")
+          format("svg");
     }
 
     @font-face {
       font-family: "Open Sans";
       font-style: italic;
       font-weight: 800;
-      src:
-        url("#{$FontPathOpenSans}/ExtraBoldItalic/OpenSans-ExtraBoldItalic.woff2")
-        format("woff2"), url("#{$FontPathOpenSans}/ExtraBoldItalic/OpenSans-ExtraBoldItalic.woff")
-        format("woff"), url("#{$FontPathOpenSans}/ExtraBoldItalic/OpenSans-ExtraBoldItalic.ttf")
-        format("truetype"), url("#{$FontPathOpenSans}/ExtraBoldItalic/OpenSans-ExtraBoldItalic.svg#OpenSansExtraboldItalic")
-        format("svg");
+      src: url("#{$FontPathOpenSans}/ExtraBoldItalic/OpenSans-ExtraBoldItalic.woff2")
+          format("woff2"),
+        url("#{$FontPathOpenSans}/ExtraBoldItalic/OpenSans-ExtraBoldItalic.woff")
+          format("woff"),
+        url("#{$FontPathOpenSans}/ExtraBoldItalic/OpenSans-ExtraBoldItalic.ttf")
+          format("truetype"),
+        url("#{$FontPathOpenSans}/ExtraBoldItalic/OpenSans-ExtraBoldItalic.svg#OpenSansExtraboldItalic")
+          format("svg");
     }
 
     @font-face {
       font-family: "Open Sans Condensed";
       font-style: normal;
       font-weight: 300;
-      src:
-        url("#{$FontPathOpenSans}/CondensedLight/OpenSans-CondensedLight.woff2")
-        format("woff2"), url("#{$FontPathOpenSans}/CondensedLight/OpenSans-CondensedLight.woff")
-        format("woff"), url("#{$FontPathOpenSans}/CondensedLight/OpenSans-CondensedLight.ttf")
-        format("truetype"), url("#{$FontPathOpenSans}/CondensedLight/OpenSans-CondensedLight.svg#OpenSansCondensedLight")
-        format("svg");
+      src: url("#{$FontPathOpenSans}/CondensedLight/OpenSans-CondensedLight.woff2")
+          format("woff2"),
+        url("#{$FontPathOpenSans}/CondensedLight/OpenSans-CondensedLight.woff")
+          format("woff"),
+        url("#{$FontPathOpenSans}/CondensedLight/OpenSans-CondensedLight.ttf")
+          format("truetype"),
+        url("#{$FontPathOpenSans}/CondensedLight/OpenSans-CondensedLight.svg#OpenSansCondensedLight")
+          format("svg");
     }
 
     @font-face {
       font-family: "Open Sans Condensed";
       font-style: italic;
       font-weight: 300;
-      src:
-        url("#{$FontPathOpenSans}/CondensedLightItalic/OpenSans-CondensedLightItalic.woff2")
-        format("woff2"), url("#{$FontPathOpenSans}/CondensedLightItalic/OpenSans-CondensedLightItalic.woff")
-        format("woff"), url("#{$FontPathOpenSans}/CondensedLightItalic/OpenSans-CondensedLightItalic.ttf")
-        format("truetype"), url("#{$FontPathOpenSans}/CondensedLightItalic/OpenSans-CondensedLightItalic.svg#OpenSansCondensedLightItalic")
-        format("svg");
+      src: url("#{$FontPathOpenSans}/CondensedLightItalic/OpenSans-CondensedLightItalic.woff2")
+          format("woff2"),
+        url("#{$FontPathOpenSans}/CondensedLightItalic/OpenSans-CondensedLightItalic.woff")
+          format("woff"),
+        url("#{$FontPathOpenSans}/CondensedLightItalic/OpenSans-CondensedLightItalic.ttf")
+          format("truetype"),
+        url("#{$FontPathOpenSans}/CondensedLightItalic/OpenSans-CondensedLightItalic.svg#OpenSansCondensedLightItalic")
+          format("svg");
     }
 
     @font-face {
       font-family: "Open Sans Condensed";
       font-style: normal;
       font-weight: 700;
-      src:
-        url("#{$FontPathOpenSans}/CondensedBold/OpenSans-CondensedBold.woff2")
-        format("woff2"), url("#{$FontPathOpenSans}/CondensedBold/OpenSans-CondensedBold.woff")
-        format("woff"), url("#{$FontPathOpenSans}/CondensedBold/OpenSans-CondensedBold.ttf")
-        format("truetype"), url("#{$FontPathOpenSans}/CondensedBold/OpenSans-CondensedBold.svg#OpenSansCondensedBold")
-        format("svg");
+      src: url("#{$FontPathOpenSans}/CondensedBold/OpenSans-CondensedBold.woff2")
+          format("woff2"),
+        url("#{$FontPathOpenSans}/CondensedBold/OpenSans-CondensedBold.woff")
+          format("woff"),
+        url("#{$FontPathOpenSans}/CondensedBold/OpenSans-CondensedBold.ttf")
+          format("truetype"),
+        url("#{$FontPathOpenSans}/CondensedBold/OpenSans-CondensedBold.svg#OpenSansCondensedBold")
+          format("svg");
     }
   } @else {
     // Open Sans


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Before this, it was impossible to import the UIKit source files
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| How to test?  | inside PrestaShop/admin-dev/new-theme/package.json, change the `prestakit` version into `NeOMakinG/prestashop-ui-kit#import-source`, and then `rm -rf node_modules && npm i && npm run build` and it should work as expected

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
