### PR TITLE
Change material icon to prod dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8535,8 +8535,7 @@
     "bootstrap": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.4.1.tgz",
-      "integrity": "sha512-tbx5cHubwE6e2ZG7nqM3g/FZ5PQEDMWmMGNrCUBVRPHXTJaH7CBDdsLeu3eCh3B1tzAxTnAbtmrzvWEvT2NNEA==",
-      "dev": true
+      "integrity": "sha512-tbx5cHubwE6e2ZG7nqM3g/FZ5PQEDMWmMGNrCUBVRPHXTJaH7CBDdsLeu3eCh3B1tzAxTnAbtmrzvWEvT2NNEA=="
     },
     "boxen": {
       "version": "4.2.0",
@@ -16441,8 +16440,7 @@
     "jquery.growl": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/jquery.growl/-/jquery.growl-1.3.5.tgz",
-      "integrity": "sha1-+hxNdY4NdoZVHhWJaxqqwrsa9/E=",
-      "dev": true
+      "integrity": "sha1-+hxNdY4NdoZVHhWJaxqqwrsa9/E="
     },
     "js-base64": {
       "version": "2.3.2",
@@ -17244,8 +17242,7 @@
     "material-design-icons-iconfont": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/material-design-icons-iconfont/-/material-design-icons-iconfont-5.0.1.tgz",
-      "integrity": "sha512-Xg6rIdGrfySTqiTZ6d+nQbcFepS6R4uKbJP0oAqyeZXJY/bX6mZDnOmmUJusqLXfhIwirs0c++a6JpqVa8RFvA==",
-      "dev": true
+      "integrity": "sha512-Xg6rIdGrfySTqiTZ6d+nQbcFepS6R4uKbJP0oAqyeZXJY/bX6mZDnOmmUJusqLXfhIwirs0c++a6JpqVa8RFvA=="
     },
     "math-expression-evaluator": {
       "version": "1.2.17",
@@ -18341,8 +18338,7 @@
     "open-sans-fonts": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/open-sans-fonts/-/open-sans-fonts-1.6.2.tgz",
-      "integrity": "sha512-vsJ6/Mm0TdUKQJqxfkXJy+0K2X0QeRuTmxQq9YE1ycziw6CbDPolDsHhQ6+ImoV/7OTh8K8ZTGklY1Z5nUAwug==",
-      "dev": true
+      "integrity": "sha512-vsJ6/Mm0TdUKQJqxfkXJy+0K2X0QeRuTmxQq9YE1ycziw6CbDPolDsHhQ6+ImoV/7OTh8K8ZTGklY1Z5nUAwug=="
     },
     "openurl": {
       "version": "1.1.1",
@@ -24933,14 +24929,12 @@
     "select2": {
       "version": "4.0.13",
       "resolved": "https://registry.npmjs.org/select2/-/select2-4.0.13.tgz",
-      "integrity": "sha512-1JeB87s6oN/TDxQQYCvS5EFoQyvV6eYMZZ0AeA4tdFDYWN3BAGZ8npr17UBFddU0lgAt3H0yjX3X6/ekOj1yjw==",
-      "dev": true
+      "integrity": "sha512-1JeB87s6oN/TDxQQYCvS5EFoQyvV6eYMZZ0AeA4tdFDYWN3BAGZ8npr17UBFddU0lgAt3H0yjX3X6/ekOj1yjw=="
     },
     "select2-bootstrap-theme": {
       "version": "0.1.0-beta.10",
       "resolved": "https://registry.npmjs.org/select2-bootstrap-theme/-/select2-bootstrap-theme-0.1.0-beta.10.tgz",
-      "integrity": "sha1-uUJuz8A79KI152oTI3dXQxBGmsA=",
-      "dev": true
+      "integrity": "sha1-uUJuz8A79KI152oTI3dXQxBGmsA="
     },
     "semver": {
       "version": "5.5.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
     "type": "git",
     "url": "https://github.com/PrestaShop/prestashop-ui-kit.git"
   },
-  "keywords": ["prestashop", "uikit"],
+  "keywords": [
+    "prestashop",
+    "uikit"
+  ],
   "scripts": {
     "watch": "webpack -w --progress --debug",
     "build": "NODE_ENV=production webpack --progress --debug",
@@ -23,6 +26,7 @@
   "dependencies": {
     "jquery.growl": "^1.3.5",
     "bootstrap": "^4.4.1",
+    "material-design-icons-iconfont": "^5.0.1",
     "select2": "^4.0.5",
     "select2-bootstrap-theme": "0.1.0-beta.10",
     "open-sans-fonts": "^1.6.2"
@@ -45,7 +49,6 @@
     "expose-loader": "^0.7.5",
     "file-loader": "^6.0.0",
     "jquery": "^3.5.0",
-    "material-design-icons-iconfont": "^5.0.1",
     "mini-css-extract-plugin": "^0.9.0",
     "node-sass": "^4.13.0",
     "popper.js": "^1.14.1",


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | We need to move the material dependency to prod dependency in order to use the UIKit with importing source files instead of dist files
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | No QA needed

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
