### PR TITLE
Add floating button to storybook

### DIFF
--- a/stories/html/floating/floating.html
+++ b/stories/html/floating/floating.html
@@ -1,0 +1,18 @@
+<div class="floating-buttons">
+  <div class="btn-floating">
+    <button
+      class="btn btn-primary collapsed"
+      data-toggle="collapse"
+      data-target=".btn-floating-container"
+    >
+      <i class="material-icons">add</i>
+    </button>
+    <div class="btn-floating-container collapse">
+      <div class="btn-floating-menu">
+        <a class="btn btn-floating-item" href="#"
+          >Upload a module <i class="material-icons">download</i></a
+        >
+      </div>
+    </div>
+  </div>
+</div>

--- a/stories/html/floating/index.stories.mdx
+++ b/stories/html/floating/index.stories.mdx
@@ -1,0 +1,14 @@
+import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import floatingContent from './floating.html'
+
+<Meta title="Floating" />
+
+# Floating button
+
+Used in the backoffice on responsive view, to contains pages actions
+
+<Canvas>
+  <Story name="Floating" parameters={{ docs: { source: { code: floatingContent } } }}>
+    {() => floatingContent}
+  </Story>
+</Canvas>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Floating button was missing in storybook while used in the BO
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Launch `npm run storybook` and go on the Flaoting button page

![image](https://user-images.githubusercontent.com/14963751/106020244-d8f8b800-60c3-11eb-8020-1f51a44a1023.png)


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
