### PR TITLE
Fix select2 initialization on storybook

### DIFF
--- a/stories/html/form/index.stories.mdx
+++ b/stories/html/form/index.stories.mdx
@@ -119,7 +119,12 @@ import loginContent from './login-example.html'
 
 <Canvas>
   <Story name="Selects" parameters={{ docs: { source: { code: selectContent } } }}>
-    {() => selectContent}
+    {() => {
+      useEffect(() => {
+        window.prestaShopUiKit.init();
+      });
+      return selectContent;
+    }}
   </Story>
 </Canvas>
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Select 2 was not initialized on storybook
| Type?             | bug fix
| How to test?      | checkout the branch, `npm run storybook` and go on Form > Selects and see if there is a select with search bar inside the page

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
