### PR TITLE
Fix modal max height on exception for example

### DIFF
--- a/scss/_modal.scss
+++ b/scss/_modal.scss
@@ -4,6 +4,7 @@ $component-name: modal;
 .#{$component-name} {
   .#{$component-name}-dialog {
     top: 50%;
+    max-height: 100vh;
   }
 
   &.show {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Sometime modal has a ultra big height, which cause a centered problem and the modal is going outside of the window
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/23497.
| How to test?      | Checkout this branch, build the UIKit, change new-theme path of prestakit to you're local UIKit, build new-theme folder, update a module which cause an exception like [boldtext (1).zip](https://github.com/PrestaShop/prestashop-ui-kit/files/6082885/boldtext.1.zip), and then check if the exception is correctly displayed

![image](https://user-images.githubusercontent.com/14963751/109951756-612f3600-7cde-11eb-867a-978d2114ab27.png)


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
