### PR TITLE
Fix anchor tag with .btn class in alert

### DIFF
--- a/scss/_alerts.scss
+++ b/scss/_alerts.scss
@@ -7,7 +7,7 @@ $component-name: alert !default;
   background-color: $white;
   @include border-radius(8px);
 
-  a {
+  a:not(.btn) {
     font-weight: 600;
     color: $gray-700;
     text-decoration: underline;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | When one uses an anchor tag <a> with the class .btn in an alert, the button will be underlined and the color won't be the one from the class .btn.
| Type?             | bug fix 
| BC breaks?        |  no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/prestashop-ui-kit/issues/157
| How to test?      | `<div class="alert alert-info" role="alert"> <p class="alert-text"> This is a info alert with <a href="#">an example link</a>. Click me to delete </p><div> <a href="//google.com" class="btn btn-secondary"> I'm an a tag </a> </div></div>`
| Possible impacts? | Don't see any

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
