### PR TITLE
Improve prestashop switch design and alignment

### DIFF
--- a/scss/_ps-switch.scss
+++ b/scss/_ps-switch.scss
@@ -3,7 +3,7 @@
   position: relative;
   display: block;
   width: 100%;
-  height: 21px;
+  height: 22px;
 
   &-nolabel {
     label {
@@ -17,32 +17,30 @@
     left: 0;
     z-index: 1;
     padding-left: 2.8rem;
+    margin-bottom: 0;
     opacity: 0;
     transform: translateY(-50%);
   }
 
   .slide-button {
-    position: relative;
     position: absolute;
-    top: 50%;
+    top: 0;
     z-index: 0;
     display: block;
-    width: 35px;
-    height: 21px;
+    width: 36px;
+    height: 22px;
     background: $gray-450;
-    transform: translateY(-50%);
     @include transition(0.25s ease-out);
     @include border-radius(1000px);
 
     &::after {
       position: absolute;
-      top: 50%;
-      left: 0;
-      width: 46%;
-      height: calc(100% - 4px);
+      top: 2px;
+      left: 2px;
+      width: 18px;
+      height: 18px;
       content: "";
       background: $white;
-      transform: translate(2px, -48%);
       @include border-radius(50%);
       @include transition(0.25s ease-out);
     }
@@ -103,7 +101,7 @@
         background: $success;
 
         &::after {
-          transform: translate(17px, -48%);
+          transform: translateX(14px);
         }
       }
     }
@@ -123,7 +121,8 @@
       height: 16px;
 
       &::after {
-        width: 37%;
+        width: 12px;
+        height: 12px;
       }
     }
   }
@@ -137,13 +136,18 @@
     }
 
     .slide-button {
-      width: 55px;
+      width: 56px;
       height: 30px;
+
+      &::after {
+        width: 26px;
+        height: 26px;
+      }
     }
 
     input:last-of-type:checked ~ .slide-button {
       &::after {
-        transform: translate(28px, -50%);
+        transform: translateX(26px);
       }
     }
   }


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | I tweaked the styles of Prestashop switches, to fix their misalignment and make them more precise, on any level of zoom. Related to https://github.com/PrestaShop/PrestaShop/pull/25087.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Partially Fixes https://github.com/PrestaShop/PrestaShop/issues/25063, do not close.
| How to test?      | Apply PR and check that forms look better.
| Possible impacts? | -

![switches](https://user-images.githubusercontent.com/6097524/122949627-1cf29f00-d37c-11eb-8b91-1ef063cc01b6.JPG)


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
