### PR TITLE
Fix spinner colors

### DIFF
--- a/scss/_spinners.scss
+++ b/scss/_spinners.scss
@@ -16,7 +16,7 @@
   animation: rotating 2s linear infinite;
 }
 
-@each $color, $value in $theme-colors-hover {
+@each $color, $value in $theme-colors {
   .spinner-#{$color} {
     border-right-color: $value;
     border-bottom-color: $value;


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Spinner colors were generated from wrong variable and their colors were switched.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/25116
| How to test?      | Insert test code below anywhere in the page, before and after PR.
| Possible impacts? | No.

**Before**
no color, primary, secondary, success, danger, warning, dark, light
![before](https://user-images.githubusercontent.com/6097524/123789565-94c14c00-d8dd-11eb-9462-7b697bd37408.JPG)

**After**
no color, primary, secondary, success, danger, warning, dark, light
![after](https://user-images.githubusercontent.com/6097524/123789570-9723a600-d8dd-11eb-9bed-379fab63575e.JPG)

**Test code**
```
<div class="spinner"></div>
&nbsp;
<div class="spinner spinner-primary"></div>
&nbsp;
<div class="spinner spinner-secondary"></div>
&nbsp;
<div class="spinner spinner-success"></div>
&nbsp;
<div class="spinner spinner-danger"></div>
&nbsp;
<div class="spinner spinner-warning"></div>
&nbsp;
<div class="spinner spinner-dark"></div>
&nbsp;
<div class="spinner spinner-light"></div>
&nbsp;
```

Ping @prestascott @NeOMakinG
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
