### PR TITLE
Fix overflowing buttons

### DIFF
--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -1,6 +1,6 @@
 .btn {
   font-weight: $font-weight-semibold;
-  white-space: nowrap;
+  white-space: normal;
   border-width: $border-width;
   @include border-radius($btn-border-radius);
 


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fixes native BS4 behavior that prevents buttons to wrap. This behavior was fixed in BS5, we need to do it manually. - related Presta PR - https://github.com/PrestaShop/PrestaShop/pull/25427
| Type?             | bug fix / improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/25422 - partially, do not close.
| How to test?      | Open storybook, open inspector, set width to iPhone 5 and make a super long button text.
| Possible impacts? | No

Before & After
![buttons](https://user-images.githubusercontent.com/6097524/126970314-ac6ae02a-7147-4ecc-a093-66ead5ddded9.jpg)


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
