### PR TITLE
Add nowrap to button as a dropdown-item

### DIFF
--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -63,6 +63,10 @@
     color: inherit;
     border-bottom: 0;
 
+    &.btn {
+      white-space: nowrap;
+    }
+
     &:hover {
       color: $primary;
       background-color: $light-blue;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Buttons as a dropdown-items are going at the line instead of extending the dropdown width
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes [26714](https://github.com/PrestaShop/PrestaShop/pull/26714#issuecomment-987724997)
| How to test?      | Add the UIKit as a local path instead of the node_module inside the package.json of new-theme and see the last comment of the PR
| Possible impacts? | Dropdowns

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
