### PR TITLE
Fix deprecation notices on divisions without calc()

### DIFF
--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -215,7 +215,7 @@ $form-check-name: form-check;
       position: absolute;
       top: 50%;
       right: 0.3125rem;
-      margin-top: -(1.375rem / 2);
+      margin-top: calc(-1.375rem / 2);
       font-size: 1.375rem;
       font-weight: $font-weight-normal;
       color: $medium-gray;

--- a/scss/_material-checkbox.scss
+++ b/scss/_material-checkbox.scss
@@ -79,12 +79,12 @@ $md-checkmark-color: $white !default;
 
         /* stylelint-disable */
         top:
-          ($md-checkbox-size / 2) - ($md-checkmark-size / 4) -
-          $md-checkbox-size / 10;
+          calc($md-checkbox-size / 2) - calc($md-checkmark-size / 4) -
+          calc($md-checkbox-size / 10);
         /* stylelint-enable */
         left: $md-checkbox-padding;
         width: $md-checkmark-size;
-        height: $md-checkmark-size / 2;
+        height: calc($md-checkmark-size / 2);
 
         border: $md-checkmark-width solid $md-checkmark-color;
         border-top-style: none;
@@ -98,7 +98,7 @@ $md-checkmark-color: $white !default;
   .indeterminate {
     + .md-checkbox-control {
       &::after {
-        top: ($md-checkbox-size / 2) - ($md-checkmark-width / 2);
+        top: calc($md-checkbox-size / 2) - calc($md-checkmark-width / 2);
         height: 0;
         transform: rotate(0);
       }

--- a/scss/_ps-tagger.scss
+++ b/scss/_ps-tagger.scss
@@ -11,7 +11,7 @@
   display: none;
   width: 100%;
   height: 100%;
-  padding: ($badge-padding-y * 1.75) $badge-padding-x;
+  padding: calc($badge-padding-y * 1.75) $badge-padding-x;
   padding-bottom: 0;
   background: $white;
   border: solid $border-width $border-color;
@@ -24,7 +24,7 @@
 
 .pstaggerTag {
   display: inline-block;
-  padding: ($badge-padding-y / 2) $badge-padding-x;
+  padding: calc($badge-padding-y / 2) $badge-padding-x;
   margin: 0 $badge-padding-x $badge-padding-y 0;
   font-size: 0.75rem;
   color: theme-color("primary");

--- a/scss/_ps-tags.scss
+++ b/scss/_ps-tags.scss
@@ -21,7 +21,7 @@
 
   .tag {
     display: inline-block;
-    padding: ($badge-padding-y / 2) $badge-padding-x;
+    padding: calc($badge-padding-y / 2) $badge-padding-x;
     margin: 0 $badge-padding-x 0 0;
     font-size: 0.75rem;
     color: theme-color("primary");

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -186,17 +186,17 @@ $spacer: 1.875rem;
 $spacers: (
   0: 0,
   1: (
-    $spacer / 6,
+    calc($spacer / 6),
   ),
   2: (
-    $spacer / 3,
+    calc($spacer / 3),
   ),
   3: (
-    $spacer / 2,
+    calc($spacer / 2),
   ),
   4: $spacer,
   5: (
-    $spacer * 2,
+    calc($spacer * 2),
   ),
 );
 


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | While building a project with a recent version of SASS, I get deprecation notices that are coming from this library (Details on the error at the bottom). 
| Type?             | refactor
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | /
| How to test?      | The result on the style must be the same as before. If something goes wrong, it would be likely the spacing between elements or ps tagger.

```
Deprecation Warning: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div($pixels, $context) or calc($pixels / $context)

More info and automated migrator: https://sass-lang.com/d/slash-div
```