### PR TITLE
Set select2 default theme to bootstrap4

### DIFF
--- a/js/prestashop-ui-kit.js
+++ b/js/prestashop-ui-kit.js
@@ -32,7 +32,7 @@ $.fn.pstooltip = $.fn.tooltip;
    */
   var initSelect2 = function () {
     jQuery('[data-toggle="select2"]').each(function () {
-      var newObj = {minimumResultsForSearch: -1};
+      var newObj = {minimumResultsForSearch: -1, theme: "bootstrap4"};
 
       for (var attr in $(this).data()) {
         if (!attr.localeCompare('templateresult')) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Set correct default theme for select2
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     |no
| Fixed ticket?     | Fixes #227, Fixes #[36448](https://github.com/PrestaShop/PrestaShop/issues/36448)
| Sponsor company   | Evolutive
| How to test?      | Check Issue 36448
