### PR TITLE
Fix sccs deprecated division outside calc

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -229,6 +229,8 @@ $enable-grid-classes: true !default;
 $enable-print-styles: true !default;
 
 // Spacing
+$spacer: 1.875rem;
+
 $spacers: (
   0: 0,
   1: (
@@ -245,7 +247,6 @@ $spacers: (
     $spacer * 2,
   ),
 );
-
 
 // Body
 $body-bg: map-get($map: $cdk-common, $key: "white");

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -233,19 +233,11 @@ $spacer: 1.875rem;
 
 $spacers: (
   0: 0,
-  1: (
-    calc($spacer / 6),
-  ),
-  2: (
-    calc($spacer / 3),
-  ),
-  3: (
-    calc($spacer / 2),
-  ),
+  1: calc($spacer / 6),
+  2: calc($spacer / 3),
+  3: calc($spacer / 2),
   4: $spacer,
-  5: (
-    $spacer * 2,
-  ),
+  5: calc($spacer * 2),
 );
 
 // Body

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -229,24 +229,23 @@ $enable-grid-classes: true !default;
 $enable-print-styles: true !default;
 
 // Spacing
-$spacer: 1.875rem;
-
 $spacers: (
   0: 0,
   1: (
-    $spacer / 6,
+    calc($spacer / 6),
   ),
   2: (
-    $spacer / 3,
+    calc($spacer / 3),
   ),
   3: (
-    $spacer / 2,
+    calc($spacer / 2),
   ),
   4: $spacer,
   5: (
     $spacer * 2,
   ),
 );
+
 
 // Body
 $body-bg: map-get($map: $cdk-common, $key: "white");


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | The prestashop project imports the _variables.scss file from prestashop-ui-kit into several theme files and warnings appear at the time of the webpack build regarding the deprecated scss division method
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #237
| Sponsor company   | Your company or customer's name goes here (if applicable).
| How to test?      | Indicate how to verify that this change works as expected.
